### PR TITLE
add ip_port_args array

### DIFF
--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -8,6 +8,7 @@
 # [*matching*]     - String to match a process
 # [*ensure*]       - If the file should be enforced or not (default: present)
 # [*ip_port*]      - Port to check if needed (zero to disable)
+# [*ip_port_args*] - Additional arguments needed for port check
 # [*socket*]       - Path to socket file if needed (undef to disable)
 # [*checks*]       - Array of monit check statements
 # [*start_script*] - Scipt used to start the process
@@ -33,6 +34,7 @@ define monit::monitor (
   $matching      = undef,
   $ensure        = present,
   $ip_port       = 0,
+  $ip_port_args  = [ ],
   $socket        = undef,
   $checks        = [ ],
   $start_script  = "/etc/init.d/${name} start",

--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -1,7 +1,7 @@
 <% if @pidfile -%>
 check process <%= @name %> with pidfile <%= @pidfile %>
 <% elsif @matching -%>
-check process <%= @name %> matching <%= @matching %>
+check process <%= @name %> matching '<%= @matching %>'
 <% end -%>
   start program = "<%= @start_script %>"<%= " as uid \"#{uid}\" and gid \"#{gid}\"" if @uid != '' and @gid != '' %>
 <% if @start_timeout -%>
@@ -12,7 +12,7 @@ check process <%= @name %> matching <%= @matching %>
     with timeout <%= @stop_timeout %> seconds
 <% end -%>
 <% if @ip_port.to_i > 0 -%>
-  if failed port <%= @ip_port %> then restart
+  if failed port <%= @ip_port %><% @ip_port_args.each do |arg| -%> <%= arg %><% end -%> then restart
 <% elsif @socket -%>
   if failed unixsocket <%= @socket %> then restart
 <% end -%>


### PR DESCRIPTION
Monit supports passing parameters to port checks ('protocol', 'request', 'status', etc.), these changes allow for passing any necessary parameters.
