### PR TITLE
Fix Puppet Warning: "Variable access via 'logfile_real' is deprecated. Use '@logfile_real' instead."

### DIFF
--- a/templates/3-mw-monit.conf.erb
+++ b/templates/3-mw-monit.conf.erb
@@ -2,7 +2,7 @@
 
 <% if @logfile_real and ! @logfile_real.empty? -%>
 # This can be helpful, even if we also send to logstash
-if $programname == 'monit' then <%= logfile_real %>
+if $programname == 'monit' then <%= @logfile_real %>
 <% end -%>
 <% if @logstash_host -%>
 


### PR DESCRIPTION
Signed-off-by: Salimane Adjao Moustapha me@salimane.com
